### PR TITLE
Update keycloak adapter in nodejs app-ui to fix redirect_uri deprecation on logout

### DIFF
--- a/code/app-ui/app.js
+++ b/code/app-ui/app.js
@@ -90,7 +90,7 @@ if (FAKE_USER === true || FAKE_USER == "true") {
     'ssl-required': 'external',
     'resource': 'client-app',
     'public-client': true,
-    'verify-token-audience': true,
+    'verify-token-audience': false,
     'use-resource-role-mappings': true,
     'confidential-port': 0
   }

--- a/code/app-ui/package.json
+++ b/code/app-ui/package.json
@@ -22,7 +22,7 @@
     "express-session": "^1.17.0",
     "http-errors": "~1.6.3",
     "kafka-node": "^4.1.3",
-    "keycloak-connect": "^8.0.2",
+    "keycloak-connect": "^18.0.2",
     "moment": "~2.24.0",
     "pug": "^2.0.4",
     "request": "^2.88.2",


### PR DESCRIPTION
Release notes: https://www.keycloak.org/2022/04/keycloak-1800-released.html

This was forcing users to leverage incognito users to switch between the `demo` and `theterminator` users.